### PR TITLE
[Fix | Feat] 新增了隐藏GUI以及壁纸模式向导通知功能和一些BUG修复

### DIFF
--- a/Assets/Resources/Textures/UI/Icons/GUI Off.png
+++ b/Assets/Resources/Textures/UI/Icons/GUI Off.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:250d1909136becd27bc944c103a165b326481857cff42966c0d3a148222b65b4
+size 8389

--- a/Assets/Resources/Textures/UI/Icons/GUI Off.png.meta
+++ b/Assets/Resources/Textures/UI/Icons/GUI Off.png.meta
@@ -1,0 +1,111 @@
+fileFormatVersion: 2
+guid: 0782fe3ebbda3cf4897fd57596d7cc0d
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Textures/UI/Icons/GUI On.png
+++ b/Assets/Resources/Textures/UI/Icons/GUI On.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ef805a093e7af629238f892d178302c6e9a101ae9399dd351f60663a961ff04
+size 8037

--- a/Assets/Resources/Textures/UI/Icons/GUI On.png.meta
+++ b/Assets/Resources/Textures/UI/Icons/GUI On.png.meta
@@ -1,0 +1,111 @@
+fileFormatVersion: 2
+guid: 142571ade948553468b6f3ed3fd8fbe0
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/ShittimCanvas.unity
+++ b/Assets/Scenes/ShittimCanvas.unity
@@ -2463,6 +2463,43 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 469372520}
   m_CullTransparentMesh: 1
+--- !u!1 &492750644
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 492750645}
+  m_Layer: 5
+  m_Name: Preserved Button Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &492750645
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 492750644}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 922954520}
+  m_Father: {fileID: 1399649036}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -115, y: -115}
+  m_SizeDelta: {x: 130, y: 130}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &505726801
 GameObject:
   m_ObjectHideFlags: 0
@@ -3105,6 +3142,79 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   is_Screenshot: 0
+--- !u!1 &626830330
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 626830331}
+  - component: {fileID: 626830333}
+  - component: {fileID: 626830332}
+  m_Layer: 5
+  m_Name: '[Hide GUI] Icon On'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &626830331
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 626830330}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 922954520}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0.00012207031}
+  m_SizeDelta: {x: 60, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &626830332
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 626830330}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 2800000, guid: 142571ade948553468b6f3ed3fd8fbe0, type: 3}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &626830333
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 626830330}
+  m_CullTransparentMesh: 1
 --- !u!1 &627471422
 GameObject:
   m_ObjectHideFlags: 0
@@ -3148,7 +3258,7 @@ RectTransform:
   - {fileID: 1010896015}
   - {fileID: 1538815400}
   m_Father: {fileID: 1399649036}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -4307,12 +4417,12 @@ RectTransform:
   - {fileID: 2071097674}
   - {fileID: 1888404351}
   m_Father: {fileID: 1399649036}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: -50, y: -50}
-  m_SizeDelta: {x: 628.2896, y: 438.3992}
+  m_SizeDelta: {x: 773.9274, y: 438.3992}
   m_Pivot: {x: 1, y: 1}
 --- !u!1 &775381622
 GameObject:
@@ -4440,7 +4550,7 @@ RectTransform:
   - {fileID: 1678984106}
   - {fileID: 2088695447}
   m_Father: {fileID: 1399649036}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -5020,6 +5130,55 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 861001231}
   m_CullTransparentMesh: 1
+--- !u!1 &864479283
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 864479284}
+  - component: {fileID: 864479285}
+  m_Layer: 0
+  m_Name: Hide GUI Services
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &864479284
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 864479283}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1457816733}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &864479285
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 864479283}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03ac9d3f7389d8646a7aa794eb13e2fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Hide_GUI_Button: {fileID: 922954522}
+  Hide_GUI_Button_Container: {fileID: 492750644}
+  GUI_On_Image: {fileID: 626830332}
+  GUI_Off_Image: {fileID: 1538487571}
+  is_GUI_Hidden: 0
 --- !u!1 &872080447
 GameObject:
   m_ObjectHideFlags: 0
@@ -5741,6 +5900,129 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   threshold: 0.1
+--- !u!1 &922954519
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 922954520}
+  - component: {fileID: 922954524}
+  - component: {fileID: 922954523}
+  - component: {fileID: 922954522}
+  m_Layer: 5
+  m_Name: '[Hide GUI] Button'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &922954520
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 922954519}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 626830331}
+  - {fileID: 1538487570}
+  m_Father: {fileID: 492750645}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -64, y: -64}
+  m_SizeDelta: {x: 128, y: 128}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &922954522
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 922954519}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 922954523}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &922954523
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 922954519}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: e887ac04caa58f6479b14ce37498d18b, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &922954524
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 922954519}
+  m_CullTransparentMesh: 1
 --- !u!1 &935311309
 GameObject:
   m_ObjectHideFlags: 0
@@ -7278,7 +7560,7 @@ RectTransform:
   - {fileID: 163092087}
   - {fileID: 1681180189}
   m_Father: {fileID: 1399649036}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
@@ -8305,6 +8587,7 @@ RectTransform:
   - {fileID: 2093904623}
   - {fileID: 709443345}
   - {fileID: 724047548}
+  - {fileID: 492750645}
   - {fileID: 770596943}
   - {fileID: 627471423}
   - {fileID: 1177199564}
@@ -8606,6 +8889,7 @@ Transform:
   - {fileID: 665850124}
   - {fileID: 615663328}
   - {fileID: 580026025}
+  - {fileID: 864479284}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -8675,7 +8959,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1399649036}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1480513305
 GameObject:
@@ -8728,7 +9012,7 @@ GameObject:
   - component: {fileID: 1489234027}
   - component: {fileID: 1489234030}
   m_Layer: 5
-  m_Name: '[VSync] Buttom'
+  m_Name: '[VSync] Button'
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -8753,7 +9037,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -256, y: 0}
+  m_AnchoredPosition: {x: -384, y: 0}
   m_SizeDelta: {x: 128, y: 128}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &1489234027
@@ -8938,7 +9222,7 @@ GameObject:
   - component: {fileID: 1518129499}
   - component: {fileID: 1518129502}
   m_Layer: 5
-  m_Name: '[Fullscreen] Buttom'
+  m_Name: '[Fullscreen] Button'
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -8963,7 +9247,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -128, y: 0}
+  m_AnchoredPosition: {x: -256, y: 0}
   m_SizeDelta: {x: 128, y: 128}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &1518129499
@@ -9061,6 +9345,79 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   threshold: 0.1
+--- !u!1 &1538487569
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1538487570}
+  - component: {fileID: 1538487572}
+  - component: {fileID: 1538487571}
+  m_Layer: 5
+  m_Name: '[Hide GUI] Icon Off'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1538487570
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1538487569}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 922954520}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 60, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1538487571
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1538487569}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 2800000, guid: 0782fe3ebbda3cf4897fd57596d7cc0d, type: 3}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &1538487572
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1538487569}
+  m_CullTransparentMesh: 1
 --- !u!1 &1538815399
 GameObject:
   m_ObjectHideFlags: 0
@@ -10005,7 +10362,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.00007803806}
+  m_AnchoredPosition: {x: 0, y: -0.000042930245}
   m_SizeDelta: {x: 472, y: 123}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &1676114036
@@ -11379,7 +11736,7 @@ GameObject:
   - component: {fileID: 1888404356}
   - component: {fileID: 1888404357}
   m_Layer: 5
-  m_Name: '[Wallpaper Mode] Buttom'
+  m_Name: '[Wallpaper Mode] Button'
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -11403,7 +11760,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -128, y: 0}
   m_SizeDelta: {x: 128, y: 128}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &1888404353
@@ -11696,7 +12053,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -383.99994, y: -3.1037}
+  m_AnchoredPosition: {x: -511.99994, y: -3.1037}
   m_SizeDelta: {x: 243.5852, y: 121.7926}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &1981913778

--- a/Assets/Scripts/BasicServices/FunctionServices/HideGUI_Services.cs
+++ b/Assets/Scripts/BasicServices/FunctionServices/HideGUI_Services.cs
@@ -1,0 +1,204 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class HideGUI_Services : MonoBehaviour
+{
+    public static HideGUI_Services Instance { get; private set; }
+    
+    private void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+            Debug.Log("[Awake] HideGUI Services 单例创建完成");
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    [Header("UI Elements")]
+    [SerializeField]
+    public Button Hide_GUI_Button;
+    [SerializeField]
+    public GameObject Hide_GUI_Button_Container; // 用于保留隐藏按钮的容器。其实也可以用在其他的Area上，来实现保留一部分UI区域的功能
+    [SerializeField]
+    public UnityEngine.UI.RawImage GUI_On_Image;
+    [SerializeField]
+    public UnityEngine.UI.RawImage GUI_Off_Image;
+
+    [Header("Core Variables")]
+    public bool is_GUI_Hidden = false;
+
+    private bool lastWallpaperMode = false;
+
+    private void Start()
+    {
+        Console_Log("开始初始化 HideGUI Services");
+        
+        if (Hide_GUI_Button != null)
+        {
+            Hide_GUI_Button.onClick.AddListener(Toggle_GUI_Visibility);
+        }
+        
+        Console_Log("结束初始化 HideGUI Services");
+        Update_GUI_Image();
+        lastWallpaperMode = IsWallpaperMode();
+    }
+
+    // 壁纸模式下，隐藏按钮跟着一块隐藏的功能
+    private void Update()
+    {
+        bool currentWallpaperMode = IsWallpaperMode();
+        if (currentWallpaperMode != lastWallpaperMode)
+        {
+            lastWallpaperMode = currentWallpaperMode;
+            Update_Hide_Button_Visibility();
+        }
+    }
+
+    private bool IsWallpaperMode()
+    {
+#if UNITY_EDITOR
+        return Wallpaper_Services.Instance != null && Wallpaper_Services.Instance.is_Wallpaper_Mode_Editor;
+#else
+        return Wallpaper_Services.Instance != null && Wallpaper_Services.Instance.is_Wallpaper_Mode;
+#endif
+    }
+
+    private void Update_Hide_Button_Visibility()
+    {
+        if (Hide_GUI_Button_Container == null) return;
+        if (IsWallpaperMode())
+        {
+            // 壁纸模式下，隐藏按钮跟着一块隐藏
+            Hide_GUI_Button_Container.SetActive(false);
+        }
+        else
+        {
+            // 非壁纸模式下，根据GUI隐藏状态决定
+            Hide_GUI_Button_Container.SetActive(true);
+        }
+    }
+
+    public void Toggle_GUI_Visibility()
+    {
+        is_GUI_Hidden = !is_GUI_Hidden;
+        
+        if (is_GUI_Hidden)
+        {
+            Console_Log("隐藏GUI");
+            Hide_GUI();
+        }
+        else
+        {
+            Console_Log("显示GUI");
+            Show_GUI();
+        }
+        Update_GUI_Image();
+    }
+
+    public void Hide_GUI()
+    {
+        is_GUI_Hidden = true;
+        
+        if (Wallpaper_Services.Instance != null)
+        {
+            // 临时保存当前状态
+            bool originalWallpaperMode = Wallpaper_Services.Instance.is_Wallpaper_Mode;
+#if UNITY_EDITOR
+            bool originalWallpaperModeEditor = Wallpaper_Services.Instance.is_Wallpaper_Mode_Editor;
+#endif
+
+            // 设置壁纸模式状态以触发Clear_HUD的隐藏逻辑
+#if UNITY_EDITOR
+            Wallpaper_Services.Instance.is_Wallpaper_Mode_Editor = true;
+#else
+            Wallpaper_Services.Instance.is_Wallpaper_Mode = true;
+#endif
+
+            // 调用Clear_HUD隐藏其他GUI
+            Wallpaper_Services.Instance.Clear_HUD();
+
+            // 恢复原始状态
+            Wallpaper_Services.Instance.is_Wallpaper_Mode = originalWallpaperMode;
+#if UNITY_EDITOR
+            Wallpaper_Services.Instance.is_Wallpaper_Mode_Editor = originalWallpaperModeEditor;
+#endif
+        }
+
+        // 保持选择的容器保持可见
+        if (Hide_GUI_Button_Container != null)
+        {
+            Hide_GUI_Button_Container.SetActive(true);
+        }
+        Update_GUI_Image();
+        Update_Hide_Button_Visibility();
+    }
+
+    public void Show_GUI()
+    {
+        is_GUI_Hidden = false;
+        
+        if (Wallpaper_Services.Instance != null)
+        {
+            bool originalWallpaperMode = Wallpaper_Services.Instance.is_Wallpaper_Mode;
+#if UNITY_EDITOR
+            bool originalWallpaperModeEditor = Wallpaper_Services.Instance.is_Wallpaper_Mode_Editor;
+#endif
+
+#if UNITY_EDITOR
+            Wallpaper_Services.Instance.is_Wallpaper_Mode_Editor = false;
+#else
+            Wallpaper_Services.Instance.is_Wallpaper_Mode = false;
+#endif
+
+            Wallpaper_Services.Instance.Clear_HUD();
+
+            //恢复原始状态
+            Wallpaper_Services.Instance.is_Wallpaper_Mode = originalWallpaperMode;
+#if UNITY_EDITOR
+            Wallpaper_Services.Instance.is_Wallpaper_Mode_Editor = originalWallpaperModeEditor;
+#endif
+        }
+        Update_GUI_Image();
+        Update_Hide_Button_Visibility();
+    }
+
+    private void Update_GUI_Image()
+    {
+        if (GUI_On_Image != null) GUI_On_Image.enabled = !is_GUI_Hidden;
+        if (GUI_Off_Image != null) GUI_Off_Image.enabled = is_GUI_Hidden;
+    }
+
+    // 留个接口，以后方便外部调用
+    public static void HideAllGUI()
+    {
+        if (Instance != null)
+        {
+            Instance.Hide_GUI();
+        }
+    }
+
+    public static void ShowAllGUI()
+    {
+        if (Instance != null)
+        {
+            Instance.Show_GUI();
+        }
+    }
+
+    public static void ToggleGUI()
+    {
+        if (Instance != null)
+        {
+            Instance.Toggle_GUI_Visibility();
+        }
+    }
+
+    private static void Console_Log(string message, Debug_Services.LogLevel loglevel = Debug_Services.LogLevel.Info, LogType logtype = LogType.Log) 
+    { 
+        Debug_Services.Instance.Console_Log("HideGUI_Services", message, loglevel, logtype); 
+    }
+} 

--- a/Assets/Scripts/BasicServices/FunctionServices/HideGUI_Services.cs.meta
+++ b/Assets/Scripts/BasicServices/FunctionServices/HideGUI_Services.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03ac9d3f7389d8646a7aa794eb13e2fc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BasicServices/FunctionServices/Wallpaper_Services.cs
+++ b/Assets/Scripts/BasicServices/FunctionServices/Wallpaper_Services.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 using System.Xml.Serialization;
+using Utils;
 
 public class Wallpaper_Services : MonoBehaviour
 {
@@ -176,6 +177,31 @@ public class Wallpaper_Services : MonoBehaviour
         Console_Log($"壁纸模式最终屏幕模式: {Screen.fullScreenMode}");
 
         Console_Log("成功进入壁纸模式");
+
+        // 6. 显示系统通知
+#if !UNITY_EDITOR
+        if (SystemTray_Services.IsNotificationEnabled)
+        {
+            try
+            {
+                TrayIcon.ShowBalloonTip(
+                    "Shittim Canvas", 
+                    "已进入壁纸模式，右键托盘图标可返回正常模式或退出软件", 
+                    TrayIcon.ToolTipIcon.Info, 
+                    true
+                );
+                Console_Log("已发送系统通知");
+            }
+            catch (Exception ex)
+            {
+                Console_Log($"发送系统通知失败: {ex.Message}", Debug_Services.LogLevel.Debug, LogType.Warning);
+            }
+        }
+        else
+        {
+            Console_Log("通知已关闭，跳过系统通知");
+        }
+#endif
     }
 
     public void Quit_Wallpaper_Mode()
@@ -197,6 +223,31 @@ public class Wallpaper_Services : MonoBehaviour
         Console_Log($"编辑模式最终屏幕模式: {Screen.fullScreenMode}");
 
         Console_Log("成功退回编辑模式");
+
+        // 显示退出壁纸模式通知
+#if !UNITY_EDITOR
+        if (SystemTray_Services.IsNotificationEnabled)
+        {
+            try
+            {
+                TrayIcon.ShowBalloonTip(
+                    "Shittim Canvas", 
+                    "已恢复正常窗口模式。", 
+                    TrayIcon.ToolTipIcon.Info, 
+                    true
+                );
+                Console_Log("已发送退出壁纸模式通知");
+            }
+            catch (Exception ex)
+            {
+                Console_Log($"发送退出壁纸模式通知失败: {ex.Message}", Debug_Services.LogLevel.Debug, LogType.Warning);
+            }
+        }
+        else
+        {
+            Console_Log("通知已关闭，跳过退出壁纸模式通知");
+        }
+#endif
     }
 
     private void Toggle_Auto_Wallpaper_Mode()

--- a/Assets/Scripts/BasicServices/SystemServices/SystemTray_Services.cs
+++ b/Assets/Scripts/BasicServices/SystemServices/SystemTray_Services.cs
@@ -8,6 +8,9 @@ public class SystemTray_Services : MonoBehaviour
     [SerializeField]
     public Texture2D SystemTray_Icon;
 
+    // 通知开关状态
+    public static bool IsNotificationEnabled = true;
+
     void Awake()
     {
 #if !UNITY_EDITOR
@@ -18,6 +21,8 @@ public class SystemTray_Services : MonoBehaviour
             ("进入壁纸模式", Enter_Wallpaper_Mode),
             ("返回正常模式", Quit_Wallpaper_Mode),
             (TrayIcon.SEPARATOR, null),
+            ("切换通知开关", Toggle_Notification),
+            (TrayIcon.SEPARATOR, null),
             ("退出", Quit_Program)
         };
 
@@ -26,6 +31,35 @@ public class SystemTray_Services : MonoBehaviour
         Debug.Log($"结束初始化系统托盘");
 #endif
     }
+
+    private void Toggle_Notification()
+    {
+        IsNotificationEnabled = !IsNotificationEnabled;
+        Debug.Log($"系统托盘触发: 切换通知状态 - {IsNotificationEnabled}");
+        
+        // 显示状态变更通知
+        ShowNotificationStatusChange();
+    }
+
+    private void ShowNotificationStatusChange()
+    {
+#if !UNITY_EDITOR
+        try
+        {
+            TrayIcon.ShowBalloonTip(
+                "Shittim Canvas", 
+                IsNotificationEnabled ? "通知已开启" : "通知已关闭", 
+                TrayIcon.ToolTipIcon.Info, 
+                true
+            );
+        }
+        catch (Exception ex)
+        {
+            Debug.LogWarning($"发送通知状态变更通知失败: {ex.Message}");
+        }
+#endif
+    }
+
     private void Enter_Wallpaper_Mode()
     {
         Debug.Log($"系统托盘触发: 进入壁纸模式");


### PR DESCRIPTION
fix(ShittimCanvas)：将“Buttom”修改为了“Button”
fix(HideGUI_Services)：修复了进入壁纸模式，”隐藏GUI”按钮不跟着一块隐藏的问题 
feat(Wallpaper_Services)：添加了进入壁纸模式时通过系统通知显示托盘运行的消息 
feat(SystemTray_Services)：添加了通知的开关，可在系统托盘菜单开启或关闭通知功能 
feat(HideGUI_Services)：将部分Clear_HUD的东西整合到这里，添加了Shittim Canvas在窗口模式下的隐藏UI功能，且支持自定义隐藏区域和外调 
asset(Icon)：添加了"GUI Off”和"GUI On"图标