### PR TITLE
Add Github issues template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-issue_zh-cn.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue_zh-cn.yml
@@ -1,0 +1,57 @@
+name: 报告问题
+description: 报告一个很明显的问题
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # 问题报告
+
+        需要注意的是，您的问题此前可能已经被报告过。在报告问题之前，请先检查以下内容：
+        - 置顶的issues, 在 https://Game-Dev-Dep/Shittim_Canvas/issues 的顶部.
+        - 标签为 `priority:0` 且open的issues， 可在[这里](https://github.com/Game-Dev-Dep/Shittim_Canvas/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Apriority%3A0)查看。
+        - 还有最重要的, 在 [issues](https://github.com/https://github.com/Game-Dev-Dep/Shittim_Canvas/issues) 中搜索。 如果您发现它已存在，请回应任何可能有用的信息。
+
+
+  - type: dropdown
+    attributes:
+      label: 类型
+      options:
+        - 崩溃
+        - 行为
+        - 性能
+        - 外观
+        - 其他
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 问题描述
+      description: 您是怎么发现这个问题的？请尽可能详细地描述。
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 截图或录屏
+      description: 添加截图或录屏可以帮助我们更快地定位问题。
+      placeholder: 拖放截图/录屏到此处。
+    validations:  
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        ## 日志
+
+        我们建议您附加日志，这可以极大的帮助我们寻找问题。 见下文来了解如何获取日志。
+
+        ### 获取日志
+
+        1. 按`Win` + `R`键打开运行窗口。
+        2. 输入`%HOMEPATH%\AppData\LocalLow\Ivaldi Forge\Shittim Canvas`，并按回车键。
+        3. 拖放 `.log` 文件到下面的日志部分。
+
+  - type: textarea
+    attributes:
+      label: 日志
+      placeholder: 拖放日志到此处。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+


### PR DESCRIPTION
This Github issues template mainly refers to the issues template of [osu](https://github.com/ppy/osu). Thanks to ppy and the development team for the excellent template.